### PR TITLE
Fixed foundry solc config to match hardhat compile bytecode

### DIFF
--- a/foundry.toml
+++ b/foundry.toml
@@ -1,12 +1,12 @@
 [profile.default]
 solc_version = '0.8.13'
 optimizer = true
-optimizer_runs = 5000
+optimizer_runs = 999999
 out = 'artifacts'
 test = 'test'
 src = 'contracts'
 libs = ['node_modules', 'lib']
+bytecode_hash = "none"
 gas_reports = ['*']
 
-fs_permissions = [{ access = "read", path = "./artifacts"}]
-
+fs_permissions = [{ access = "read", path = "./artifacts" }]

--- a/test/utils/index.ts
+++ b/test/utils/index.ts
@@ -151,7 +151,7 @@ export default async function (chain2?: boolean): Promise<PreTest> {
   const chainId: BytesLike = '0x' + network.holographId.toString(16).padStart(8, '0');
   const chainId2: BytesLike = '0x' + network2.holographId.toString(16).padStart(8, '0');
   const fixtures: string[] = [
-    'HolographGenesis',
+    ['localhost', 'localhost2'].includes(hre.networkName) ? 'HolographGenesisLocal' : 'HolographGenesis',
     'Holograph',
     'HolographBridge',
     'HolographBridgeProxy',
@@ -271,7 +271,9 @@ export default async function (chain2?: boolean): Promise<PreTest> {
   holographErc721 = (await hre.ethers.getContract('HolographERC721')) as HolographERC721;
   holographFactory = (await hre.ethers.getContract('HolographFactory')) as HolographFactory;
   holographFactoryProxy = (await hre.ethers.getContract('HolographFactoryProxy')) as HolographFactoryProxy;
-  holographGenesis = (await hre.ethers.getContract('HolographGenesis')) as HolographGenesis;
+  holographGenesis = (await hre.ethers.getContract(
+    ['localhost', 'localhost2'].includes(hre.networkName) ? 'HolographGenesisLocal' : 'HolographGenesis'
+  )) as HolographGenesis;
   holographOperator = (await hre.ethers.getContract('HolographOperator')) as HolographOperator;
   holographOperatorProxy = (await hre.ethers.getContract('HolographOperatorProxy')) as HolographOperatorProxy;
   holographRegistry = (await hre.ethers.getContract('HolographRegistry')) as HolographRegistry;


### PR DESCRIPTION
## Describe Changes

Changes performed: 
- The main objective was to get the same deployedBytecode when compiling with foundry, than we have when doing so with hardhat. We changed the solidity compiler options on foundry to match the hardhat ones. 
- Modified the deploy scripts to get the correct `HolographGenesis` when deploying in localhost

## Checklist before requesting a review

- [x] I have performed a self-review of my code
- [x] Code styles have been enforced
- [ ] All Hardhat tests are passing
